### PR TITLE
Prevent the parser from choking on KSP 1.1.3 savefiles

### DIFF
--- a/js/parse_sfs.js
+++ b/js/parse_sfs.js
@@ -43,6 +43,11 @@ this.parse_sfs = (function(){
         .replace(/[ \t]+\n/g,'\n')
         .replace(/[\r\n]+/g,'\n')
         .replace("\x05","")
+
+        // Horrible hack to remove the LoaderInfo section, which is unparseable
+        // by this parser but I can't find the generator for the parser
+        // anywhere.  Hope you don't have any modules with "{" or "}" in the name!
+        .replace(/LoaderInfo\s+\{[^}]+\}/, "")
         + "\n")
     }
 


### PR DESCRIPTION
The parser doesn't like the LoaderInfo section.  For instance, in one of
my savefiles it looks like:

    LoaderInfo
    {
      ModuleManager.2.6.24 v2.6.24.0 = True
      ContractConfigurator v1.0.0.0 / v1.16.2 = True
      ContractModifier v1.0.2.3 / vv2.3 = True
      ContractParser v1.0.4.0 / vv4.0 = True
      ProgressParser v1.0.5.0 / vv5.0 = True

and parse_sfs.js chokes on the "v" in v2.6.24.0.  I think it's looking
for the "=" and is apparently not prepared for this format of key at
this position.  The parser is generaged from PEG.js, but I couldn't find
the input to PEG anywhere, so I just modified the "clean_stage" function
to strip out LoaderInfo because we don't need it.